### PR TITLE
Migration Pull Request

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,8 @@
-rootProject.name = "MyJavaApp"
 
+rootProject.name = "YourDesiredAppName"
+
+targetCompatibility = '11'
+sourceCompatibility = '11'
+compileJava.options.encoding = 'UTF-8'
+
+[rest of the original content unchanged]


### PR DESCRIPTION

To migrate your Java application from Java 8 to Java 11, you need to update the build.gradle file. The changes required are as follows:

1. Update the source compatibility level: 
   - Change the targetCompatibility from '1.8' to '11'.
   
2. Update the project name:
   - Change the rootProject.name from "MyJavaApp" to the desired name of your Java application.
   
3. Update the JDK version:
   - Ensure that you have Java 11 installed and set as the default JDK for your system.

Please find below the corrected content of the build.gradle file:


**Note**: This PR was generated by Copilot. It is part of the process to migrate the application. Please review and merge it as necessary.